### PR TITLE
fix: 백업 데이터 파일 크기를 0으로 저장하던 오류 수정

### DIFF
--- a/src/main/java/com/sprint/part2/sb1hrbankteam03/service/BackupServiceImpl.java
+++ b/src/main/java/com/sprint/part2/sb1hrbankteam03/service/BackupServiceImpl.java
@@ -268,6 +268,7 @@ public class BackupServiceImpl implements BackupService {
 
         byte[] fileContent = inputStream.readAllBytes();
 
+        backupFile.setFileSize((long) fileContent.length);
         //파일 메타데이터 저장
         FileMetaData savedFile = fileMetaDataRepository.save(backupFile);
 


### PR DESCRIPTION
### 데이터 백업 파일 다운로드 시 빈 파일 다운되는 이슈 #62 
- ` backupFile.setFileSize((long) fileContent.length);` 추가하여 수정하였습니다.