### PR TITLE
[Feature/employee] 직원 이력 기록 로직 책임 분리 및 추가 수정

### DIFF
--- a/src/main/java/com/sprint/part2/sb1hrbankteam03/dto/employeeHistory/EmployeeChangeInfo.java
+++ b/src/main/java/com/sprint/part2/sb1hrbankteam03/dto/employeeHistory/EmployeeChangeInfo.java
@@ -1,0 +1,12 @@
+package com.sprint.part2.sb1hrbankteam03.dto.employeeHistory;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class EmployeeChangeInfo {
+  private final String field;
+  private final String oldValue;
+  private final String newValue;
+}

--- a/src/main/java/com/sprint/part2/sb1hrbankteam03/service/EmployeeHistoryService.java
+++ b/src/main/java/com/sprint/part2/sb1hrbankteam03/service/EmployeeHistoryService.java
@@ -2,8 +2,8 @@ package com.sprint.part2.sb1hrbankteam03.service;
 
 import com.sprint.part2.sb1hrbankteam03.dto.employeeHistory.CursorPageResponseChangeLogDto;
 import com.sprint.part2.sb1hrbankteam03.dto.employeeHistory.DiffDto;
+import com.sprint.part2.sb1hrbankteam03.dto.employeeHistory.EmployeeChangeInfo;
 import com.sprint.part2.sb1hrbankteam03.entity.ChangeType;
-import com.sprint.part2.sb1hrbankteam03.entity.EmployeeChangeDetail;
 import com.sprint.part2.sb1hrbankteam03.entity.EmployeeHistory;
 import java.time.Instant;
 import java.util.List;
@@ -11,14 +11,12 @@ import org.springframework.data.domain.Pageable;
 
 public interface EmployeeHistoryService {
 
-  EmployeeHistory createHistory(String employeeNumber, ChangeType type, String memo);
+  EmployeeHistory createHistoryWithDetails(String employeeNumber, ChangeType type, String memo, List<EmployeeChangeInfo> infos, String ipAddress);
 
   CursorPageResponseChangeLogDto getChangeLogs(
       String employeeNumber, String memo, String ipAddress, ChangeType changeType,
       Instant atFrom, Instant atTo, String cursor, Long idAfter, String sortField,
       String sortDirection, Pageable pageable);
-
-  void saveChangeDetails(EmployeeHistory history, List<EmployeeChangeDetail> details);
 
   List<DiffDto> getChangeDetails(Long historyId);
 

--- a/src/main/java/com/sprint/part2/sb1hrbankteam03/service/EmployeeService.java
+++ b/src/main/java/com/sprint/part2/sb1hrbankteam03/service/EmployeeService.java
@@ -13,12 +13,10 @@ public interface EmployeeService {
   CursorPageResponseEmployeeDto getEmployees(String keyword, String department, String position,
       String employeeNumber, String startDate, String endDate,
       String status,String sortField, String sortDirection,String cursor,int size);
-  EmployeeDto createEmployee(EmployeeCreateRequest request,
-      MultipartFile profile);
+  EmployeeDto createEmployee(EmployeeCreateRequest request, MultipartFile profile, String ipAddress);
   EmployeeDto getEmployeeById(Long employeeId);
-  EmployeeDto updateEmployee(Long employeeId, EmployeeUpdateRequest request,
-      MultipartFile profile);
-  void deleteEmployee(Long employeeId);
+  EmployeeDto updateEmployee(Long employeeId, EmployeeUpdateRequest request, MultipartFile profile, String ipAddress);
+  void deleteEmployee(Long employeeId, String ipAddress);
   List<EmployeeTrendDto> getAllEmployTrend(String startDate, String endDate, String unit);
   List<EmployeeDistributionDto> getEmployeeDistribution(String groupBy, String status);
   long getTotalEmployeeCount(String status, String fromDate, String toDate);


### PR DESCRIPTION
- EmployeeService에서 EmployeeHistoryService로 이력 기록 책임 위임
- createHistoryWithDetails 메서드로 이력/상세 기록 통합
- 클라이언트 IP 컨트롤러에서 추출하여 서비스에 전달
- 트랜잭션 처리 보강: 이력 기록 메서드 @Transactional 추가
- 변경사항 없어도 무조건 이력 기록하도록 개선