### PR TITLE
[Refactor/Employee] 직원 이력 기록 구조 개선 및 변경 추적 로직 리팩토링

### DIFF
--- a/src/main/java/com/sprint/part2/sb1hrbankteam03/dto/employeeHistory/EmployeeChangeInfo.java
+++ b/src/main/java/com/sprint/part2/sb1hrbankteam03/dto/employeeHistory/EmployeeChangeInfo.java
@@ -3,6 +3,7 @@ package com.sprint.part2.sb1hrbankteam03.dto.employeeHistory;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
+
 @Getter
 @AllArgsConstructor
 public class EmployeeChangeInfo {

--- a/src/main/java/com/sprint/part2/sb1hrbankteam03/dto/employeeHistory/EmployeeSnapshotDto.java
+++ b/src/main/java/com/sprint/part2/sb1hrbankteam03/dto/employeeHistory/EmployeeSnapshotDto.java
@@ -1,0 +1,17 @@
+package com.sprint.part2.sb1hrbankteam03.dto.employeeHistory;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class EmployeeSnapshotDto {
+  private String employeeNumber;
+  private String name;
+  private String email;
+  private String department;
+  private String position;
+  private String hireDate;
+  private String status;
+}

--- a/src/main/java/com/sprint/part2/sb1hrbankteam03/mapper/EmployeeMapper.java
+++ b/src/main/java/com/sprint/part2/sb1hrbankteam03/mapper/EmployeeMapper.java
@@ -2,6 +2,7 @@ package com.sprint.part2.sb1hrbankteam03.mapper;
 
 import com.sprint.part2.sb1hrbankteam03.dto.employee.CursorPageResponseEmployeeDto;
 import com.sprint.part2.sb1hrbankteam03.dto.employee.EmployeeDto;
+import com.sprint.part2.sb1hrbankteam03.dto.employeeHistory.EmployeeSnapshotDto;
 import com.sprint.part2.sb1hrbankteam03.entity.Employee;
 import java.util.List;
 import org.springframework.stereotype.Component;
@@ -42,4 +43,17 @@ public class EmployeeMapper {
         hasNext
     );
   }
+
+  public EmployeeSnapshotDto toSnapshotDto(Employee employee) {
+    return new EmployeeSnapshotDto(
+        employee.getEmployeeNumber(),
+        employee.getName(),
+        employee.getEmail(),
+        employee.getDepartment().getName(),
+        employee.getPosition(),
+        employee.getHireDate().toString(),
+        employee.getStatus().name()
+    );
+  }
+
 }

--- a/src/main/java/com/sprint/part2/sb1hrbankteam03/service/EmployeeHistoryService.java
+++ b/src/main/java/com/sprint/part2/sb1hrbankteam03/service/EmployeeHistoryService.java
@@ -2,16 +2,15 @@ package com.sprint.part2.sb1hrbankteam03.service;
 
 import com.sprint.part2.sb1hrbankteam03.dto.employeeHistory.CursorPageResponseChangeLogDto;
 import com.sprint.part2.sb1hrbankteam03.dto.employeeHistory.DiffDto;
-import com.sprint.part2.sb1hrbankteam03.dto.employeeHistory.EmployeeChangeInfo;
+import com.sprint.part2.sb1hrbankteam03.dto.employeeHistory.EmployeeSnapshotDto;
 import com.sprint.part2.sb1hrbankteam03.entity.ChangeType;
-import com.sprint.part2.sb1hrbankteam03.entity.EmployeeHistory;
 import java.time.Instant;
 import java.util.List;
 import org.springframework.data.domain.Pageable;
 
 public interface EmployeeHistoryService {
 
-  EmployeeHistory createHistoryWithDetails(String employeeNumber, ChangeType type, String memo, List<EmployeeChangeInfo> infos, String ipAddress);
+  void recordHistoryFromSnapshot(EmployeeSnapshotDto before, EmployeeSnapshotDto after, ChangeType type, String memo, String ipAddress);
 
   CursorPageResponseChangeLogDto getChangeLogs(
       String employeeNumber, String memo, String ipAddress, ChangeType changeType,


### PR DESCRIPTION
- EmployeeService에서 필드 단위 이력 기록 로직 제거
- SnapshotDto 기반 변경 전/후 비교 방식으로 이력 기록 책임 분리
- EmployeeMapper에 toSnapshotDto 메서드 추가
- recordHistoryFromSnapshot 메서드에서 변경 필드 자동 추적
- 퇴사인 경우 삭제 제한 로직 제거 → 퇴사 여부 상관없이 삭제 가능하게 변경